### PR TITLE
Server verifyChallenge method returns address or null

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ app.post('/auth', (req, res) => {
     return res.status(400).json({ error: 'Missing signature or message' });
   }
   
-  // Verify the signed challenge
-  const isValid = authServer.verifyChallenge(message, signedMessage);
+  // Verify the signed challenge and extract the wallet address
+  const address = authServer.verifyChallenge(message, signedMessage);
   
-  if (isValid) {
-    // Create a session or JWT token for the authenticated user
-    // ...
-    
-    res.json({ success: true });
-  } else {
+  if (!address) {
     res.status(401).json({ error: 'Invalid signature' });
   }
+
+  // Create a session or JWT token for the authenticated user
+  // ...
+
+  res.json({ success: true });
 });
 
 app.listen(3000, () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@evmauth/eip712-authn",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "TypeScript library for secure authentication via EIP-712 message signing to verify ownership of a wallet address.",
     "type": "module",
     "exports": {

--- a/src/server/auth-server.ts
+++ b/src/server/auth-server.ts
@@ -26,7 +26,7 @@ export class AuthServer {
         );
     }
 
-    verifyChallenge(message: EIP712AuthMessage, signedMessage: string): boolean {
+    verifyChallenge(message: EIP712AuthMessage, signedMessage: string): string | null {
         return verifyChallenge(message, signedMessage, this.config.jwtSecret);
     }
 }
@@ -63,15 +63,15 @@ export function verifyChallenge(
     message: EIP712AuthMessage,
     signedMessage: string,
     jwtSecret: string
-): boolean {
+): string | null {
     if (!message?.domain || !message?.auth) {
-        return false;
+        return null;
     }
 
     const expectedAddress: string = jwt.verify(message.auth.challenge, jwtSecret) as string;
 
     if (!expectedAddress || !isAddress(expectedAddress)) {
-        return false;
+        return null;
     }
 
     const signerAddress = verifyTypedData(
@@ -82,8 +82,12 @@ export function verifyChallenge(
     );
 
     if (!signerAddress || !isAddress(signerAddress)) {
-        return false;
+        return null;
     }
 
-    return signerAddress.toLowerCase() === expectedAddress.toLowerCase();
+    if (signerAddress.toLowerCase() !== expectedAddress.toLowerCase()) {
+        return null;
+    }
+
+    return signerAddress;
 }

--- a/test/server/auth-server.test.ts
+++ b/test/server/auth-server.test.ts
@@ -126,7 +126,7 @@ describe('AuthServer', () => {
                 message.auth,
                 signedMessage
             );
-            expect(result).toBe(true);
+            expect(result).toBe(walletAddress);
         });
     });
 });
@@ -219,7 +219,7 @@ describe('verifyChallenge function', () => {
         vi.clearAllMocks();
     });
 
-    it('should return true when challenge is valid and addresses match', () => {
+    it('should return address when challenge is valid and addresses match', () => {
         vi.mocked(jwt.verify).mockReturnValue(walletAddress);
         vi.mocked(ethers.isAddress).mockReturnValue(true);
         vi.mocked(ethers.verifyTypedData).mockReturnValue(walletAddress);
@@ -234,43 +234,43 @@ describe('verifyChallenge function', () => {
             message.auth,
             signedMessage
         );
-        expect(result).toBe(true);
+        expect(result).toBe(walletAddress);
     });
 
-    it('should return false when message is invalid', () => {
+    it('should return null when message is invalid', () => {
         const result = verifyChallenge({} as EIP712AuthMessage, signedMessage, jwtSecret);
-        expect(result).toBe(false);
+        expect(result).toBe(null);
     });
 
-    it('should return false when JWT verification fails', () => {
+    it('should return null when JWT verification fails', () => {
         // Looking at the implementation, we need to return undefined to simulate JWT verification failure
         vi.mocked(jwt.verify).mockReturnValue(undefined);
 
         const result = verifyChallenge(message, signedMessage, jwtSecret);
 
-        expect(result).toBe(false);
+        expect(result).toBe(null);
     });
 
-    it('should return false when JWT payload is not a valid address', () => {
+    it('should return null when JWT payload is not a valid address', () => {
         vi.mocked(jwt.verify).mockReturnValue('not-an-address');
         vi.mocked(ethers.isAddress).mockReturnValue(false);
 
         const result = verifyChallenge(message, signedMessage, jwtSecret);
 
-        expect(result).toBe(false);
+        expect(result).toBe(null);
     });
 
-    it('should return false when verifyTypedData returns invalid address', () => {
+    it('should return null when verifyTypedData returns invalid address', () => {
         vi.mocked(jwt.verify).mockReturnValue(walletAddress);
         vi.mocked(ethers.isAddress).mockReturnValueOnce(true).mockReturnValueOnce(false);
         vi.mocked(ethers.verifyTypedData).mockReturnValue('invalid-address');
 
         const result = verifyChallenge(message, signedMessage, jwtSecret);
 
-        expect(result).toBe(false);
+        expect(result).toBe(null);
     });
 
-    it('should return false when addresses do not match', () => {
+    it('should return null when addresses do not match', () => {
         const differentAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
         vi.mocked(jwt.verify).mockReturnValue(walletAddress);
         vi.mocked(ethers.isAddress).mockReturnValue(true);
@@ -278,6 +278,6 @@ describe('verifyChallenge function', () => {
 
         const result = verifyChallenge(message, signedMessage, jwtSecret);
 
-        expect(result).toBe(false);
+        expect(result).toBe(null);
     });
 });


### PR DESCRIPTION
## Description

This PR modifies the `verifyChallenge` server method to return the authenticated wallet address on success, or `null` on failure. Previously, this method returned `true` on success, and `false` on failure.

Fixes #1 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

- [x] Unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings