### PR TITLE
Verify challenge throws `AuthError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ app.listen(3000, () => {
 });
 ```
 
+## Auth Server Errors
+
+All error classes below extend the `AuthError` class, which extends `Error`.
+
+| Error Class | Description                                                                    |
+|-------------|--------------------------------------------------------------------------------|
+| `InvalidJWTError` | The EIP-712 message `challenge` JWT is invalid or expired.                     |
+| `InvalidMessageError` | The unsigned EIP-712 message is invalid or does not match the expected format. |
+| `InvalidSignatureError` | The signed EIP-712 message is invalid or does not match the expected format.   |
+| `SignatureMismatchError` | The EIP-712 message signer address does not match the `challenge` JWT address. |
+
 ## License
 
 The **EVMAuth** TypeScript EIP-712 Authentication is released under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@evmauth/eip712-authn",
-    "version": "0.2.3",
+    "version": "0.3.0",
     "description": "TypeScript library for secure authentication via EIP-712 message signing to verify ownership of a wallet address.",
     "type": "module",
     "exports": {

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,0 +1,34 @@
+export class AuthError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AuthError';
+    }
+}
+
+export class InvalidJWTError extends AuthError {
+    constructor(message = 'Invalid JWT token') {
+        super(message);
+        this.name = 'InvalidJWTError';
+    }
+}
+
+export class InvalidMessageError extends AuthError {
+    constructor(message = 'Invalid EIP-712 message') {
+        super(message);
+        this.name = 'InvalidMessageError';
+    }
+}
+
+export class InvalidSignatureError extends AuthError {
+    constructor(message = 'Invalid signature') {
+        super(message);
+        this.name = 'InvalidSignatureError';
+    }
+}
+
+export class SignatureMismatchError extends AuthError {
+    constructor(message = 'Signature does not match expected address') {
+        super(message);
+        this.name = 'SignatureMismatchError';
+    }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,3 +5,10 @@ export type {
     EIP712AuthMessage,
     EIP712AuthChallenge,
 } from '../common/types.js';
+export type {
+    AuthError,
+    InvalidJWTError,
+    InvalidMessageError,
+    InvalidSignatureError,
+    SignatureMismatchError,
+} from './errors.js';


### PR DESCRIPTION
## Description

This PR correctly handles the JWT payload in the server method `verifyChallenge`, and changes the behavior of that method by making it throw an `AuthError` on failure.

These specific errors have been added, all of which extend `AuthError`: 
-  `InvalidJWTError`
- `InvalidMessageError`
- `InvalidSignatureError`
- `SignatureMismatchError`

This makes troubleshooting much easier, and gives developers the ability to handle each of the various errors differently.

Fixes #9 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

- [x] Unit tests
- [x] Manual tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
